### PR TITLE
Fixes the side nav icons and background color

### DIFF
--- a/lib/nav/side/side_panel.css
+++ b/lib/nav/side/side_panel.css
@@ -1,4 +1,4 @@
-:host-context header {
+:host ::ng-deep header {
   background-color: #eee;
 }
 
@@ -12,6 +12,6 @@
   align-items: center;
 }
 
-.header glyph {
+.header material-icon {
   margin-right: 6px;
 }

--- a/lib/nav/side/side_panel.dart
+++ b/lib/nav/side/side_panel.dart
@@ -6,6 +6,7 @@ import 'package:angular/core.dart';
 
 // TODO: use a non-private implementation
 import 'package:angular_components/src/components/material_expansionpanel/material_expansionpanel.dart';
+import 'package:angular_components/src/components/material_icon/material_icon.dart';
 import 'package:angular_components/src/utils/browser/dom_service/dom_service.dart';
 
 import 'package:gwt_mail_sample/contact/contact_list.dart';
@@ -20,6 +21,7 @@ import 'package:gwt_mail_sample/task/task_list.dart';
     ContactList,
     MailFolder,
     MaterialExpansionPanel,
+    MaterialIconComponent,
     TaskList,
   ],
 )

--- a/lib/nav/side/side_panel.html
+++ b/lib/nav/side/side_panel.html
@@ -4,7 +4,7 @@
     [expanded]="selectedPanel == 'mailboxes'"
     (open)="open('mailboxes')">
   <div name class="header">
-    <div><glyph icon="mail_outline"></glyph></div>
+    <div><material-icon icon="mail_outline"></material-icon></div>
     <div>Mailboxes</div>
   </div>
   <div class="content" [style.height.px]="heightPx">
@@ -17,7 +17,7 @@
     [expanded]="selectedPanel == 'tasks'"
     (open)="open('tasks')">
   <div name class="header">
-    <div><glyph icon="view_list"></glyph></div>
+    <div><material-icon icon="view_list"></material-icon></div>
     <div>Tasks</div>
   </div>
   <div class="content" [style.height.px]="heightPx">
@@ -30,7 +30,7 @@
     [expanded]="selectedPanel == 'contacts'"
     (open)="open('contacts')">
   <div name class="header">
-    <div><glyph icon="contact_mail"></glyph></div>
+    <div><material-icon icon="contact_mail"></material-icon></div>
     <div>Contacts</div>
   </div>
   <div class="content" [style.height.px]="heightPx">


### PR DESCRIPTION
During the migration from `GlyphComponent` to `MaterialIconComponent`,
`SidePanel` was not completely migrated. Its headers were also relying on a
style encapsulation bug with `:host-context` to pierce component boundaries.